### PR TITLE
Fix scraping of months

### DIFF
--- a/pycate/cate.py
+++ b/pycate/cate.py
@@ -270,16 +270,22 @@ class CATe(object):
 
                 # Find month at first labelled day
                 first_labelled_datetime = None
-                k = first_labelled_day
+                k = i
+                offset = 0
                 for month in month_colspans:
                     k -= month["colspan"]
 
                     # If the current month hasn't been found yet keep
                     # going
-                    if k > 0:
+                    if k >= 0:
                         continue
 
-                    first_labelled_month = month_search(month["name"])
+                    first_labelled_month = month_search(month["name"]) - offset
+
+                    # Keep on going until we find a legible month name
+                    if first_labelled_month < 0:
+                        offset += 1
+                        continue
 
                     # Use 1st September as the cut off between academic
                     # years

--- a/pycate/models.py
+++ b/pycate/models.py
@@ -2,6 +2,14 @@ from enum import Enum
 from typing import Dict
 
 
+class SubscriptionLevel(Enum):
+    UNKNOWN = "UNKNOWN"
+
+    DISCARD = "0"
+    CATE_SUBMISSIONS = "2"
+    EXAM_REGISTRATION = "3"
+
+
 class AssessedStatus(Enum):
     UNKNOWN = "UNKNOWN"
 
@@ -86,6 +94,7 @@ class Exercise:
         self,
         module_number: str,
         module_name: str,
+        module_subscription_level: SubscriptionLevel,
         code: str,
         name: str,
         start: str,
@@ -97,6 +106,7 @@ class Exercise:
     ):
         self.__module_number = module_number
         self.__module_name = module_name
+        self.__module_subscription_level = module_subscription_level
         self.__code = code
         self.__name = name
         self.__start = start
@@ -118,6 +128,10 @@ class Exercise:
     @property
     def module_name(self) -> str:
         return self.__module_name
+
+    @property
+    def module_subscription_level(self) -> SubscriptionLevel:
+        return self.__module_subscription_level
 
     @property
     def code(self) -> str:

--- a/pycate/util.py
+++ b/pycate/util.py
@@ -21,36 +21,21 @@ def month_search(s):
     """
     Tries to match the given month name with a month number (1-12)
     """
-    s = s.lower()
-    s0 = s.lower()[0]  # save calculating it all the time
-    s1 = s.lower()[1]
-    if s0 == "j":
-        if s1 == "a":
-            return 1
-        elif s1 == "u":
-            if s[2] == "n":
-                return 6
-            elif s[2] == "l":
-                return 7
-    elif s0 == "f":
-        return 2
-    elif s0 == "m":
-        if s1 == "a":
-            if s[2] == "r":
-                return 3
-            elif s[2] == "y":
-                return 5
-    elif s0 == "a":
-        if s1 == "p":
-            return 4
-        elif s1 == "u":
-            return 8
-    elif s0 == "s":
-        return 9
-    elif s0 == "o":
-        return 10
-    elif s0 == "n":
-        return 11
-    elif s0 == "d":
-        return 12
+    m = {
+        'jan': 1,
+        'feb': 2,
+        'mar': 3,
+        'apr': 4,
+        'may': 5,
+        'jun': 6,
+        'jul': 7,
+        'aug': 8,
+        'sep': 9,
+        'oct': 10,
+        'nov': 11,
+        'dec': 12
+    }
+    s = s.strip()[:3].lower()
+    if s in m:
+        return m[s]
     return -1

--- a/pycate/util.py
+++ b/pycate/util.py
@@ -22,18 +22,18 @@ def month_search(s):
     Tries to match the given month name with a month number (1-12)
     """
     m = {
-        'jan': 1,
-        'feb': 2,
-        'mar': 3,
-        'apr': 4,
-        'may': 5,
-        'jun': 6,
-        'jul': 7,
-        'aug': 8,
-        'sep': 9,
-        'oct': 10,
-        'nov': 11,
-        'dec': 12
+        "jan": 1,
+        "feb": 2,
+        "mar": 3,
+        "apr": 4,
+        "may": 5,
+        "jun": 6,
+        "jul": 7,
+        "aug": 8,
+        "sep": 9,
+        "oct": 10,
+        "nov": 11,
+        "dec": 12
     }
     s = s.strip()[:3].lower()
     if s in m:


### PR DESCRIPTION
Currently, pycate fails to scrape CATe, since it always gets the first two characters for a month, but currently the first month in CATe only has 1 character ("S" for September).

Also, the first labelled date this term is not in September, but October, suggesting there's an error in the logic for getting the month for the first labelled date.

#### This PR:
* Refactors the `month_search` function to make it a lot more readable, and remove the requirement for the input string to be at least 2 characters long (although at least 3 chars are now required to get a match).
* To reach the first labelled month, we start with the count of unlabelled days (`k = i`), and decrement this by the span of the current month until the value is negative (i.e. we know that we have passed all of the unlabelled dates).
* If we cannot read the first labelled month (i.e. there's less than 3 chars), then we continue to the next month, try and read that one, and work out from there what the first month must have been.

#### Testing:
I've tested this manually with:
* 2018 period 1
* 2018 period 2
* 2017 period 5

which I think covers most of the edge cases.